### PR TITLE
Fix comment reinsertion

### DIFF
--- a/src/language/formatter.ts
+++ b/src/language/formatter.ts
@@ -18,7 +18,10 @@ class Formatter {
 
   private formattedCode: string = '';
 
+  private originalCode: string;
+
   constructor(code: string) {
+    this.originalCode = code;
     const obj = jsonata(code).ast();
     this.evaluate(obj);
 
@@ -153,7 +156,13 @@ class Formatter {
     this.p('\n)');
   }
 
+  // eslint-disable-next-line consistent-return
   private evaluateCondition(obj: jsonata.ExprNode) {
+    const operator = this.originalCode.slice((obj.position ?? 0) - 2, obj.position);
+    if (operator === '??' || operator === '?:') {
+      // @ts-ignore
+      return this.evaluateBinary({ lhs: obj.then, rhs: obj.else, value: operator });
+    }
     // @ts-ignore
     this.evaluate(obj.condition);
     this.i();

--- a/src/language/formatter.ts
+++ b/src/language/formatter.ts
@@ -245,7 +245,10 @@ class Formatter {
   }
 
   private evaluateRegex(obj: jsonata.ExprNode) {
-    this.p(obj.value.toString());
+    // Remove the g from the regex string
+    // JSONata AST parser adds the g flag to the regex string for evaluation
+    // But it's not valid JSONata syntax
+    this.p(obj.value.toString().replace(/(\/.*?)g(.*$)/, '$1$2'));
   }
 
   private evaluateBinary(obj: jsonata.ExprNode) {

--- a/src/language/formatter.ts
+++ b/src/language/formatter.ts
@@ -272,10 +272,17 @@ class Formatter {
       // @ts-ignore
       this.evaluate(obj.steps[i]);
 
-      // @ts-ignore
-      if (obj.steps[i].stages) {
-        // @ts-ignore
-        obj.steps[i].stages?.forEach((e) => this.evaluate(e));
+      if (obj.steps?.[i]?.stages) {
+        // JSONata AST parser creates duplicate stages for ?? and ?: operators
+        // so we need to make sure we only evaluate each stage once
+        const seenStageIds = new Set<string>();
+        obj.steps?.[i]?.stages?.forEach((stage) => {
+          const slug = `${stage.type}-${stage.position}`;
+          if (!seenStageIds.has(slug)) {
+            seenStageIds.add(slug);
+            this.evaluate(stage);
+          }
+        });
       }
     }
     // @ts-ignore

--- a/src/language/formatter.ts
+++ b/src/language/formatter.ts
@@ -494,7 +494,8 @@ class CommentPreservingFormatter {
         commentText = comments.map((c) => c.text).join('\n');
         front = formattedCode.slice(0, insertPosition);
         back = formattedCode.slice(insertPosition);
-        commentText = CommentPreservingFormatter.reindentComments(commentText, 0);
+        const indent = back.match(/^\n?( *)/s)?.[1].length || 0;
+        commentText = ' '.repeat(indent) + CommentPreservingFormatter.reindentComments(commentText, indent);
         if (/[^\n]$/.test(front)) {
           front += '\n';
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-console, no-sequences, no-continue */
+export function deepEqual(a: any, b: any, seen = new WeakMap()) {
+  // Strict equality check (handles primitives, null, undefined, same reference)
+  if (a === b) return true;
+  // Type checking
+  if (typeof a !== typeof b) return console.warn('Type mismatch', a, b), false;
+  if (a == null || b == null) return console.warn('Null mismatch', a, b), false;
+  // Handle circular references
+  if (typeof a === 'object') {
+    if (seen.has(a)) return seen.get(a) === b ? true : (console.warn('Circular reference mismatch', a, b), false);
+    seen.set(a, b);
+  }
+  // Handle arrays
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return console.warn('Array length mismatch', a, b), false;
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i], seen)) return console.warn('Array element mismatch', a[i], b[i]), false;
+    }
+    return true;
+  }
+  // Handle Date objects
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+  // Handle RegExp objects
+  if (a instanceof RegExp && b instanceof RegExp) {
+    return a.toString() === b.toString() ? true : (console.warn('RegExp mismatch', a, b), false);
+  }
+  // Handle plain objects
+  if (typeof a === 'object' && a.constructor === Object && b.constructor === Object) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return console.warn('Object key length mismatch', keysA.length, keysB.length), false;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of keysA) {
+      if (key === 'position') continue; // skip position key since we're formatting
+      if (!keysB.includes(key)) return console.warn('Object key mismatch', key, a, b), false;
+      if (!deepEqual(a[key], b[key], seen)) return console.warn('Object value mismatch', key, a[key], b[key]), false;
+    }
+    return true;
+  }
+  console.warn('Object mismatch', a, b);
+  // For other object types, use strict equality, which failed above
+  return false;
+}
+
+export function deepEqualWithFunctions(a: any, b: any, seen = new WeakMap()) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return console.warn('Type mismatch', a, b), false;
+  if (a == null || b == null) return console.warn('Null mismatch', a, b), false;
+  // Handle functions
+  if (typeof a === 'function' && typeof b === 'function') {
+    return a.toString() === b.toString() ? true : (console.warn('Function mismatch', a, b), false);
+  }
+  // Delegate to main comparison
+  return deepEqual(a, b, seen);
+}


### PR DESCRIPTION
The upstream library (and now this fork) is using the AST generated by https://github.com/jsonata-js/jsonata/ to parse and format the code, and some quirks of the AST implementation that broke our output.

- the parser rewrites usage of `??` and `?:` operators as ternaries, so we have to put those back
- the parser adds the `g` flag to regular expressions, which are therefore forbidden in the syntax, so we have to strip those out
- the parser seems to have a bug when building `path` nodes from expressions using `??` or `?:` -- the bug has zero impact on the evaluated output of the template, but it led to duplication of some syntax when turning those nodes back into text
- the parser's logic for trailing paths/filters was not being handled, so we were outputting completely broken code

In addition to fixing these errors, we've cleaned up indentation for standalone comments and the formatting for empty blocks, arrays, and objects.

Also, since we don't yet know what else we might have missed in the subtleties of turning the AST backing to text, we've added validation to make sure that the AST generated by our formatted code is the same as the AST generated by the original code -- if they're not the same, we don't edit the original code.